### PR TITLE
switched to openrouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,23 @@
     <img src="https://img.shields.io/badge/License-MIT-green" alt="License: MIT" />
 </p>
 
-
-Walter is an automated trading assistant that pulls real-time market context from Hyperliquid, asks a Gemini-powered LLM to decide whether to buy, sell, or hold, and optionally routes market orders when the model is confident enough. It is designed for fast strategy prototyping, not unattended production trading.
+Walter is an automated trading assistant that pulls real-time market context from Hyperliquid, asks a LLM to decide whether to buy, sell, or hold, and optionally routes market orders when the model is confident enough. It is designed for fast strategy prototyping, not unattended production trading.
 
 ## Features
+
 - Aggregates Hyperliquid mid prices, candles, volume, funding, and trade pressure into a concise market snapshot.
-- Evaluates open positions and market context with a Gemini 1.5 Flash model and enforces a configurable confidence threshold before executing.
+- Evaluates open positions and market context with a LLM model and enforces a configurable confidence threshold before executing.
 - Places market or limit orders through the official Hyperliquid SDK with automatic tick-size snapping and leverage updates.
 - Runs as a simple scheduler loop (configurable interval) so you can monitor output and interrupt with `Ctrl+C`.
 
 ## Requirements
+
 - Python 3.10+
 - Hyperliquid API access (public key plus a funded wallet private key for execution).
-- Google Gemini API key with access to `gemini-1.5-flash`.
+- OpenRouter API key.
 
 ## Installation
+
 ```bash
 git clone <your fork or repo url>
 cd walter
@@ -34,23 +36,26 @@ pip install -e .
 ```
 
 ## Configuration
+
 Create a `.env` or `.env.local` file (both are loaded if present) and provide at least:
 
-| Variable | Purpose |
-| --- | --- |
-| `SCHEDULER_INTERVAL_SECONDS` | Seconds between decision cycles (default `60`). |
-| `COIN` | Hyperliquid asset ticker, e.g. `BTC`. |
-| `HYPERLIQUID_URL` | Base URL for the Hyperliquid info endpoint. |
-| `GENERAL_PUBLIC_KEY` | Public key used when fetching existing positions. |
-| `API_WALLET_PRIVATE_KEY` | Private key that signs orders. |
-| `ORDER_SIZE` | Position size in coin terms (default `0.5`). |
-| `ORDER_LEVERAGE` | Leverage passed to Hyperliquid before each order. |
-| `ORDER_TIF` | Time-in-force for limit payloads, e.g. `Ioc` or `Gtc`. |
-| `GEMINI_API_KEY` | Google Gemini API key used by the LLM client. |
+| Variable                     | Purpose                                                                                   |
+| ---------------------------- | ----------------------------------------------------------------------------------------- |
+| `SCHEDULER_INTERVAL_SECONDS` | Seconds between decision cycles (default `60`).                                           |
+| `COIN`                       | Hyperliquid asset ticker, e.g. `BTC`.                                                     |
+| `HYPERLIQUID_URL`            | Base URL for the Hyperliquid info endpoint.                                               |
+| `GENERAL_PUBLIC_KEY`         | Public key used when fetching existing positions.                                         |
+| `API_WALLET_PRIVATE_KEY`     | Private key that signs orders.                                                            |
+| `ORDER_SIZE`                 | Position size in coin terms (default `0.5`).                                              |
+| `ORDER_LEVERAGE`             | Leverage passed to Hyperliquid before each order.                                         |
+| `ORDER_TIF`                  | Time-in-force for limit payloads, e.g. `Ioc` or `Gtc`.                                    |
+| `OPENROUTER_API_KEY`         | OpenRouter API key for unified LLM access.                                                |
+| `LLM_MODEL`                  | (Optional) Model to use, e.g., `gemini-flash`, `deepseek-r1`. Defaults to `gemini-flash`. |
 
-You can also override the default Gemini model or token lists by editing `walter/LLM_API.py`.
+Walter uses OpenRouter to access a wide range of free and paid models. See `src/walter/LLM_API.py` for a list of popular free models you can use with `LLM_MODEL`.
 
 ## Usage
+
 ```bash
 python main.py
 ```
@@ -58,6 +63,7 @@ python main.py
 The script prints each market snapshot, open position payload, the LLM decision, and order status. Stop the loop with `Ctrl+C`.
 
 ## Development
+
 - Run tests: `pytest`
 - Format/lint: `ruff check .`
 - The core modules live in `src/walter/` (`market_data.py`, `LLM_API.py`, `hyperliquid_API.py`, `utils.py`).

--- a/main.py
+++ b/main.py
@@ -15,8 +15,9 @@ coin = str(os.getenv("COIN"))
 hyperliquid_url = str(os.getenv("HYPERLIQUID_URL"))
 general_public_key = str(os.getenv("GENERAL_PUBLIC_KEY"))
 api_wallet_private_key = str(os.getenv("API_WALLET_PRIVATE_KEY"))
-gemini_key = os.getenv("GEMINI_API_KEY")
-llm_api = LLMAPI(api_key=gemini_key)
+llm_model = os.getenv("LLM_MODEL")
+openrouter_key = os.getenv("OPENROUTER_API_KEY")
+llm_api = LLMAPI(api_key=openrouter_key, model=llm_model or "gemini-flash")
 
 def main() -> None:
     print(f"Scheduler running every {interval} seconds.")


### PR DESCRIPTION
# Description:
This PR replaces the previous gemini api with multiple llm yet unified integration via OpenRouter. This simplifies the codebase, removes the dependency on the Google GenAI SDK, and provides access to a wider range of models (including many free ones) with a single API key.

# Key Changes:

src/walter/LLM_API.py:

-  Removed complex, multi-provider logic and the google-genai dependency.

- Implemented a lightweight, unified client for OpenRouter.

- Updated POPULAR_MODELS to focus on high-quality free models (e.g., gemini-flash, deepseek-r1, llama-3.2).

main.py:

- Updated to use OPENROUTER_API_KEY instead of provider-specific keys.

- Added support for the LLM_MODEL environment variable to easily switch models.

Documentation:
- Updated README.md with new configuration steps and model options.

# How to Test:
1. Get a free API key from [openrouter.ai](https://openrouter.ai/).
2. Set OPENROUTER_API_KEY in your .env or .env.local.
3. (Optional) Set LLM_MODEL=deepseek-r1 (or leave default gemini-flash).
4. Run python main.py and verify that market analysis and trading decisions occur.