### PR TITLE
11 add news to llm prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ def main() -> None:
                     hyperliquid_url, general_public_key
                 )
                 print(accountSnapshot)
-                decision = llm_api.decide_from_market(marketSnapshot, accountSnapshot)
+                decision = llm_api.decide_from_market(marketSnapshot, accountSnapshot, major_titles)
                 print(f"Thinking: {decision.thinking}")
                 print(decision)
                 if decision.action == "hold":

--- a/src/walter/LLM_API.py
+++ b/src/walter/LLM_API.py
@@ -100,7 +100,7 @@ class LLMAPI:
         # History length for recent decisions
         self.history_length = history_length
 
-    def get_prompt(self, market_snapshot: Any, open_positions: Any) -> str:
+    def get_prompt(self, market_snapshot: Any, open_positions: Any, news_titles: list[str] | None = None) -> str:
         """Builds a concise instruction prompt for the LLM."""
 
         recent_decisions = get_recent_decisions(self.history_length)
@@ -136,6 +136,9 @@ class LLMAPI:
             f"{history_text}"
             f"Current Market Snapshot: {market_snapshot}\n"
             f"Current Open Positions: {open_positions}\n"
+            f"Current News Headlines: {', '.join(news_titles) if news_titles else 'No news available'}\n"
+            "Factor the news sentiment into your decision — positive news may support BUY, "
+            "negative news may support SELL or HOLD.\n"
             "Answer in JSON format (example below):\n"
             f"""{{
             "THINKING": "Short reasoning here...",
@@ -204,11 +207,11 @@ class LLMAPI:
         )
 
     def decide_from_market(
-        self, market_snapshot: Any, open_positions: Any
+        self, market_snapshot: Any, open_positions: Any, news_titles: list[str] | None = None
     ) -> LLMDecision:
         """Invokes OpenRouter with generated prompt and parses the response."""
 
-        prompt = self.get_prompt(market_snapshot, open_positions)
+        prompt = self.get_prompt(market_snapshot, open_positions, news_titles)
         response = self._call_openrouter(prompt)
         return self.decide(response)
 


### PR DESCRIPTION
## PR Checklist

Please confirm the following before opening this PR:

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have updated the README.md with any necessary information about the changes.
- [ ] I have linked any relevant issues that this PR addresses.
- [ ] I have updated the `config.py` defaults if I have added new configuration options.

---

### Description
Feed news headlines into the LLM prompt

The bot was already fetching and summarizing crypto news via CryptoNewsAggregator, but the headlines were only saved to the database — never passed to the LLM when making trading decisions.

Changes:

Added news_titles parameter to  get_prompt() and decide_from_market() in LLM_API.py (defaults to None for backward compatibility)
Prompt now includes a "Current News Headlines" section with guidance to factor sentiment into buy/sell/hold decisions
Updated main.py to pass major_titles to the LLM call

### Note
**I know this issue was assigned to you, but it took me just a quick prompt to wrap it up. Sorry if I stepped on your toes—feel free to close the PR if you’d rather handle it. @davidwardan** 
